### PR TITLE
fix: generate id for score-create events (scores silently dropped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New example file `examples/simplified_usage.rb` demonstrating the simplified API
 - Comprehensive test coverage for convenience methods (28 new tests)
 
+### Fixed
+- `Client#score` now generates an `id` for `score-create` events when none is supplied
+  (also fixes `Trace#score` / `Generation#score`, which delegate to it). Previously scores
+  were enqueued without an `id`; Langfuse's ingestion API accepts such events (HTTP 201) but
+  the worker never persists them, so user feedback scores silently never appeared. This brings
+  `score` in line with `trace`/`span`/`generation`, which already self-generate ids.
+
 ## [0.1.5] - 2025-12-26
 
 ### Added

--- a/lib/langfuse/client.rb
+++ b/lib/langfuse/client.rb
@@ -332,6 +332,7 @@ module Langfuse
     # Score/Evaluation operations
     def score(name:, value:, trace_id: nil, observation_id: nil, data_type: nil, comment: nil, **kwargs)
       data = {
+        id: kwargs.delete(:id) || Utils.generate_id,
         name: name,
         value: value,
         data_type: data_type,

--- a/spec/langfuse/client_spec.rb
+++ b/spec/langfuse/client_spec.rb
@@ -79,6 +79,18 @@ RSpec.describe Langfuse::Client do
         value: 0.8
       )
     end
+
+    it 'generates an id when none is provided' do
+      expect(client).to receive(:enqueue_event).with('score-create', hash_including(:id))
+
+      client.score(trace_id: 'test_trace_id', name: 'test_score', value: 0.8)
+    end
+
+    it 'keeps an explicitly provided id' do
+      expect(client).to receive(:enqueue_event).with('score-create', hash_including(id: 'custom-id'))
+
+      client.score(trace_id: 'test_trace_id', name: 'test_score', value: 0.8, id: 'custom-id')
+    end
   end
 
   describe '#flush' do


### PR DESCRIPTION
## Problem

`Client#score` enqueues a `score-create` event **without a `body.id`**. Langfuse's ingestion API accepts such events (`207` / `{status: 201}`, no error returned), but the worker never persists the score — so scores created through the SDK **silently never appear** in the UI/ClickHouse. This also affects `Trace#score` and `Generation#score`, which delegate to `Client#score` (and the `trace.score(...)` example in the README reproduces it).

## Cause

`trace`, `span`, `generation` and the other observation types all self-generate an id (`id || Utils.generate_id`). `score` was the only entity that didn't, so its events go out without the client-owned id Langfuse needs to persist/deduplicate them.

## Reproduction (self-hosted Langfuse v3)

| event | result |
|-------|--------|
| `score-create` **without** `body.id` | `201` accepted → **0 rows** in ClickHouse `scores` |
| identical event **with** `body.id`   | persisted ✅ |

`client.score(name:, value:, trace_id:)` followed by `flush` returns success but stores nothing; adding an `id` makes it land.

## Fix

Generate an `id` in `score` (honouring an explicit `id:` kwarg when supplied), mirroring how `trace`/`span`/`generation` already behave. One line, plus specs and a CHANGELOG entry.
